### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: App build
 on:
   push:
     branches:
-      - add-build-workflow
+      - main
 jobs:
   build_and_release:
     runs-on: macos-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: App build
+
+on:
+  push:
+    branches:
+      - add-build-workflow
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - run: npm ci
+      - run: npm run dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,19 @@ on:
     branches:
       - add-build-workflow
 jobs:
-  build:
+  build_and_release:
     runs-on: macos-14
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: "22.x"
       - name: authenticate with github package registry
-        run: npm set "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
+        run: npm set "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}"
       - run: npm ci
       - run: npm run dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - add-build-workflow
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4
@@ -14,5 +14,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+      - name: authenticate with github package registry
+        run: npm set "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
       - run: npm ci
       - run: npm run dist

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: ci 
+name: docs publish 
 on:
   push:
     branches:

--- a/Readme.md
+++ b/Readme.md
@@ -71,14 +71,10 @@ All dependencies and scripts are listed in the single `package.json` at the top 
 
 ## Releases and versions
 
-The [Changelog](./Changelog.md) and [GitHub Releases](https://github.com/bbc/audio-orchestrator/releases) are updated manually, usually on minor version increments (e.g. `0.17.0` to `0.18.0`). We create a Github release linked to a git tag for that version.
+A [GitHub action](.github/workflows/build.yml) automatically attaches built installers to a draft release when a PR is merged into the main branch, and a draft release with the tag name `v${version}` matching the package.json version exists.
 
-To create a release build run the `npm run dist` task. Attach these files to the release on GitHub:
-
-- `dist/Audio Orchestrator-<version>.dmg`
-- `dist/Audio Orchestrator-<version>-arm64.dmg`
-- `dist/Audio Orchestrator Setup <version>.exe`
+NB apps built this way are not signed or notarized by Apple/Microsoft and may require additional authorization to run. This is the same as with the MakerBox installers distributed previously.
 
 ## History
 
-_Audio Orchestrator_ was originally developed in the [BBC R&D](https://www.bbc.co.uk/rd/) Audio Team by Kristian Hentschel with contributions from Jon Francombe, Emma Young, Danial Haddadi, and Sonal Tandon between 2019 and 2022. It was distributed through the BBC _Connected Studio MakerBox_, and to several public pilots on [BBC Taster](https://www.bbc.co.uk/taster/). The software is now available to interested members of the community through this Audio Orchestrator open source repository, but will not see significant further development from the BBC.
+_Audio Orchestrator_ was originally developed in the [BBC R&D](https://www.bbc.co.uk/rd/) Audio Team by Kristian Hentschel with contributions from Jon Francombe, Emma Young, Danial Haddadi, and Sonal Tandon between 2019 and 2022. It was distributed through the BBC _Connected Studio MakerBox_ site, and used in several public pilots on [BBC Taster](https://www.bbc.co.uk/taster/). The software is now available to interested members of the community through this Audio Orchestrator open source repository, but will not see significant further development from the BBC.

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "webpack-dev-server": "^5.2.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Audio Orchestrator",
   "description": "Audio Orchestrator is an production tool for prototyping multi-device audio experiences.",
   "repository": "https://github.com/bbc/audio-orchestrator",
-  "version": "0.23.1",
+  "version": "0.23.2-dev",
   "author": "BBC R&D",
   "license": "GPL-3.0-or-later",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Audio Orchestrator",
   "description": "Audio Orchestrator is an production tool for prototyping multi-device audio experiences.",
   "repository": "https://github.com/bbc/audio-orchestrator",
-  "version": "0.23.2-dev",
+  "version": "0.23.1",
   "author": "BBC R&D",
   "license": "GPL-3.0-or-later",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-3.0-or-later",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build:react-frontend": "(cd react-frontend && webpack --mode production)",


### PR DESCRIPTION
See: https://www.electron.build/publish.html

The workflow should run on pushes to the main branch and automatically upload the built installers to a GitHub release.

1. Update package.json version on your branch.
2. Create draft release with a new tag matching the package.json version (with `v` prefix, ie., `v0.23.2`).
3. Merge the PR to main.
4. Check the binaries attached to the draft release.
5. Publish the draft release; github will create the tag automatically.
