### PR TITLE
Add upload-artifact action to manually download the built installers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,12 @@ jobs:
         with:
           name: dist
           path: |
-            dist/Audio Orchestrator-*.dmg.dmg
-            dist/Audio Orchestrator-Setup *.exe
-            dist/latest.yml
-            dist/builder-effective-config.yaml
+            dist/*.dmg
+            dist/*.dmg.blockmap
+            dist/*.exe
+            dist/*.exe.blockmap
+            dist/*.yaml
+            dist/*.yml
         
 
+# dist/Audio Orchestrator Setup 0.23.1.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path:
-            - dist/Audio Orchestrator-*.dmg.dmg
-            - dist/Audio Orchestrator-Setup *.exe
-            - dist/latest.yml
-            - dist/builder-effective-config.yaml
+          path: |
+            dist/Audio Orchestrator-*.dmg.dmg
+            dist/Audio Orchestrator-Setup *.exe
+            dist/latest.yml
+            dist/builder-effective-config.yaml
         
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - upload-artifact-action
 jobs:
   build:
     runs-on: macos-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
-  build_and_release:
+  build:
     runs-on: macos-14
 
     env:
@@ -23,3 +21,14 @@ jobs:
         run: npm set "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}"
       - run: npm ci
       - run: npm run dist
+      - name: Upload installers to action runs
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path:
+            - dist/Audio Orchestrator-*.dmg.dmg
+            - dist/Audio Orchestrator-Setup *.exe
+            - dist/latest.yml
+            - dist/builder-effective-config.yaml
+        
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - upload-artifact-action
 jobs:
   build:
     runs-on: macos-14
@@ -33,6 +32,3 @@ jobs:
             dist/*.exe.blockmap
             dist/*.yaml
             dist/*.yml
-        
-
-# dist/Audio Orchestrator Setup 0.23.1.exe

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,8 +3,10 @@
 This changelog summarises changes for minor and major version bumps that end users might need to be aware of. The commit log should provide a more detailed list of changes for developers; most changes to internal systems are not discussed here.
 
 ---
-# `0.23.1`
+# `0.23.1` (public release)
+  _2025-01-29_
   * Change location of support and log files to `~/Library/Application Support/Audio Orchestrator` / `%APPDATA%/Audio Orchestrator`
+  * Change name of default export folder to begin with `audio-orchestrator`.
 
 # `0.23.0`
   _2025-01-17_

--- a/Readme.md
+++ b/Readme.md
@@ -71,9 +71,11 @@ All dependencies and scripts are listed in the single `package.json` at the top 
 
 ## Releases and versions
 
-A [GitHub action](.github/workflows/build.yml) automatically attaches built installers to a draft release when a PR is merged into the main branch, and a draft release with the tag name `v${version}` matching the package.json version exists.
+Pull requests should update the main package.json version and run `npm install && npm run credits` to ensure this is used throughout. Changelog.md should also be manually updated.
 
-NB apps built this way are not signed or notarized by Apple/Microsoft and may require additional authorization to run. This is the same as with the MakerBox installers distributed previously.
+A [GitHub action](.github/workflows/build.yml) automatically builds mac and windows installers on pushes to the main branch. These must then be manually checked and attached to a GitHub release.
+
+NB apps built this way are not signed or notarized by Apple/Microsoft and may require additional authorization to run.
 
 ## History
 

--- a/Readme.md
+++ b/Readme.md
@@ -71,11 +71,9 @@ All dependencies and scripts are listed in the single `package.json` at the top 
 
 ## Releases and versions
 
-Pull requests should update the main package.json version and run `npm install && npm run credits` to ensure this is used throughout. Changelog.md should also be manually updated.
+Pull requests should update the main `package.json` version and run `npm install && npm run credits` before they are merged to ensure the new version is used throughout. Changelog.md should also be manually updated.
 
-A [GitHub action](.github/workflows/build.yml) automatically builds mac and windows installers on pushes to the main branch. These must then be manually checked and attached to a GitHub release.
-
-NB apps built this way are not signed or notarized by Apple/Microsoft and may require additional authorization to run.
+Currently, releases are locally built (`npm run dist`) and manually uploaded to GitHub (macOS, macOS-arm64, Windows).
 
 ## History
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "credits": "node scripts/credits.mjs",
     "dev": "concurrently \"npm run dev:react-frontend\" \"NODE_ENV=development electron --inspect=9229 .\"",
     "dev:react-frontend": "(cd react-frontend && webpack-dev-server --hot --host 0.0.0.0 --mode development)",
-    "dist": "((rm -r ./dist || echo '') && npm run credits && cp electron-app/credits.html electron-app/credits2.html && npm run build:react-frontend && electron-builder --config electron-builder.json --mac --win)",
+    "dist": "((rm -r ./dist || echo '') && npm run credits && cp electron-app/credits.html electron-app/credits2.html && npm run build:react-frontend && electron-builder --config electron-builder.json --mac --win --publish never)",
     "lint": "npm run lint:background-tasks && npm run lint:react-frontend && npm run lint:electron-app && npm run lint:logging",
     "lint:background-tasks": "cd background-tasks && eslint src test",
     "lint:electron-app": "cd electron-app && eslint src",


### PR DESCRIPTION
NB the installers produced from this do not currently work on macOS because no developer certificate is configured. For now we will manually upload releases.